### PR TITLE
fixed style of the comment box

### DIFF
--- a/portfolio/src/main/webapp/styles/comments.css
+++ b/portfolio/src/main/webapp/styles/comments.css
@@ -265,7 +265,7 @@ main {
 
 .comment-content {
     position: relative;
-    width: 100%;
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -277,11 +277,13 @@ main {
     margin-top: 20px;
     margin-bottom: 50px;
     width: 100%;
+    justify-content: start;
+    word-break: break-all;
 }
 
 .comment-date {
     position: absolute;
-    width: 100%;
+    width: auto;
     text-align: end;
     bottom: 0;
     margin-top: 0;


### PR DESCRIPTION
When I was doing Blobstore feature, I noticed that comment text goes outside of the box if it's too long (I know that a long time ago there wasn't such problem, but today it was). 